### PR TITLE
[FEAT] 이메일/닉네임 중복체크, 로그인 상태체크 API 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,5 @@ out/
 ### VS Code ###
 .vscode/
 
-### Environment Variables ###
-.env
-.env.local
-.env.production
-.env.staging
+### QueryDSL generated sources ###
+src/main/generated/

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,11 @@ out/
 ### VS Code ###
 .vscode/
 
+### Environment Variables ###
+.env
+.env.local
+.env.production
+.env.staging
+
 ### QueryDSL generated sources ###
 src/main/generated/

--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'org.springframework.boot:spring-boot-starter-security'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	testRuntimeOnly 'com.h2database:h2'
@@ -42,6 +43,11 @@ dependencies {
 	implementation 'com.fasterxml.jackson.core:jackson-databind'
 	implementation 'com.fasterxml.jackson.core:jackson-annotations'
 
+	// JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.5'
+
 	// QueryDSL 추가
 	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
 	annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
@@ -53,7 +59,7 @@ dependencies {
 }
 
 tasks.named('test') {
-	useJUnitPlatform()
+    useJUnitPlatform()
 }
 
 // ===== QueryDSL 설정 시작 =====

--- a/src/main/generated/com/salemale/domain/user/entity/QUser.java
+++ b/src/main/generated/com/salemale/domain/user/entity/QUser.java
@@ -33,19 +33,17 @@ public class QUser extends EntityPathBase<User> {
 
     public final NumberPath<Long> id = createNumber("id", Long.class);
 
-    public final StringPath loginPw = createString("loginPw");
-
-    public final EnumPath<com.salemale.global.common.enums.LoginType> loginType = createEnum("loginType", com.salemale.global.common.enums.LoginType.class);
-
     public final NumberPath<Integer> mannerScore = createNumber("mannerScore", Integer.class);
 
     public final StringPath nickname = createString("nickname");
 
+    public final StringPath phoneNumber = createString("phoneNumber");
+
+    public final DateTimePath<java.time.LocalDateTime> phoneVerifiedAt = createDateTime("phoneVerifiedAt", java.time.LocalDateTime.class);
+
     public final StringPath profileImage = createString("profileImage");
 
-    public final EnumPath<User.rangeSetting> rangeSetting = createEnum("rangeSetting", User.rangeSetting.class);
-
-    public final StringPath socialId = createString("socialId");
+    public final EnumPath<User.RangeSetting> rangeSetting = createEnum("rangeSetting", User.RangeSetting.class);
 
     //inherited
     public final DateTimePath<java.time.LocalDateTime> updatedAt = _super.updatedAt;

--- a/src/main/java/com/salemale/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/salemale/common/code/status/ErrorStatus.java
@@ -22,6 +22,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 사용자 관련 에러
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수입니다."),
+    USER_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER4003", "이미 가입된 이메일입니다."),
 
     // 경매 관련 에러 (나중에 추가)
     AUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "AUCTION4001", "경매를 찾을 수 없습니다."),

--- a/src/main/java/com/salemale/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/salemale/common/code/status/ErrorStatus.java
@@ -24,6 +24,7 @@ public enum ErrorStatus implements BaseErrorCode {
     USER_NOT_FOUND(HttpStatus.BAD_REQUEST, "USER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER4002", "닉네임은 필수입니다."),
     USER_EMAIL_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "USER4003", "이미 가입된 이메일입니다."),
+    AUTH_INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "AUTH4011", "아이디 또는 비밀번호가 올바르지 않습니다."),
 
     // 경매 관련 에러 (나중에 추가)
     AUCTION_NOT_FOUND(HttpStatus.NOT_FOUND, "AUCTION4001", "경매를 찾을 수 없습니다."),

--- a/src/main/java/com/salemale/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/salemale/common/code/status/ErrorStatus.java
@@ -15,6 +15,7 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON401","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
     _NOT_FOUND(HttpStatus.NOT_FOUND, "COMMON404", "요청한 리소스를 찾을 수 없습니다."),
+    _TOO_MANY_REQUESTS(HttpStatus.TOO_MANY_REQUESTS, "COMMON429", "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."),
 
     // 테스트용
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "테스트용 예외입니다."),

--- a/src/main/java/com/salemale/domain/user/controller/AuthController.java
+++ b/src/main/java/com/salemale/domain/user/controller/AuthController.java
@@ -1,0 +1,54 @@
+package com.salemale.domain.user.controller; // 인증 HTTP 엔드포인트 정의(로그인/회원가입/로그아웃 등)
+
+import com.salemale.common.response.ApiResponse; // 통일된 API 응답 포맷 래퍼
+import com.salemale.domain.user.dto.request.LoginRequest; // 로그인 요청 DTO(email/password)
+import com.salemale.domain.user.dto.request.SignupRequest; // 회원가입 요청 DTO(email/nickname/password)
+import com.salemale.domain.user.service.AuthService; // 인증 비즈니스 로직 서비스(로그인/회원가입 등)
+import jakarta.validation.Valid; // 요청 바디 검증
+import org.springframework.http.ResponseEntity; // HTTP 응답 래퍼
+import org.springframework.web.bind.annotation.PostMapping; // POST 매핑
+import org.springframework.web.bind.annotation.PatchMapping; // PATCH 매핑(로그아웃 등 상태변경용)
+import org.springframework.web.bind.annotation.RequestBody; // 요청 바디 바인딩
+import org.springframework.web.bind.annotation.RequestMapping; // 베이스 경로 매핑
+import org.springframework.web.bind.annotation.RestController; // REST 컨트롤러 선언
+
+import java.util.Map; // 간단한 키/값 응답을 위해 사용
+
+@RestController
+@RequestMapping("/auth") // 모든 인증 관련 경로는 /auth 하위로 통일(/auth/login, /auth/register, /auth/logout)
+public class AuthController { // 인증 관련 엔드포인트 집합(초심자도 이해할 수 있도록 상세 주석 포함)
+
+    private final AuthService authService;
+
+    public AuthController(AuthService authService) { // 생성자를 통해 서비스 의존성 주입
+        this.authService = authService; // 스프링이 AuthService 빈을 자동으로 넣어줍니다.
+    }
+
+    @PostMapping("/login") // 로그인: 사용자가 이메일/비밀번호를 보내면 서버가 확인 후 토큰을 발급해 줍니다.
+    public ResponseEntity<ApiResponse<Map<String, String>>> login(@Valid @RequestBody LoginRequest request) {
+        // 1) @Valid: request에 적힌 @Email, @NotBlank 등의 검사를 먼저 수행합니다.
+        // 2) 서비스에 로그인 요청: 비밀번호 해시 검증에 성공하면 JWT 토큰이 문자열로 돌아옵니다.
+        String token = authService.loginLocal(request.getEmail(), request.getPassword());
+        // 3) ApiResponse.onSuccess로 성공 응답을 표준 형태로 감싸서 반환합니다.
+        //    응답 본문 예시: { "isSuccess": true, "code": "200", "message": "OK", "result": { "accessToken": "..." } }
+        return ResponseEntity.ok(ApiResponse.onSuccess(Map.of("accessToken", token)));
+    }
+
+    @PostMapping("/register") // 회원가입: 새 사용자를 만들고 로컬 자격(이메일/비번)을 저장합니다.
+    public ResponseEntity<ApiResponse<Void>> register(@Valid @RequestBody SignupRequest request) {
+        // 1) 이메일/닉네임/비밀번호 입력 검증(@Valid)
+        // 2) 서비스에 위임: 중복 이메일 검사 → User 생성 → UserAuth(LOCAL) 생성(비밀번호 해시)
+        authService.registerLocal(request);
+        // 3) 생성 성공 시 바디 없이 성공 응답을 반환합니다.
+        return ResponseEntity.ok(ApiResponse.onSuccess());
+    }
+
+    @PatchMapping("/logout") // 로그아웃: JWT는 서버가 상태를 저장하지 않으므로 보통 클라이언트에서 토큰을 버립니다.
+    public ResponseEntity<ApiResponse<Void>> logout() {
+        // 서버 세션을 쓰지 않는 JWT 구조에서는 서버가 무언가 지울 상태가 없습니다.
+        // 실서비스에선 "블랙리스트" 저장소를 운용하거나, 클라이언트가 토큰을 삭제하도록 안내합니다.
+        return ResponseEntity.ok(ApiResponse.onSuccess());
+    }
+}
+
+

--- a/src/main/java/com/salemale/domain/user/controller/AuthController.java
+++ b/src/main/java/com/salemale/domain/user/controller/AuthController.java
@@ -56,10 +56,13 @@ public class AuthController { // 인증 관련 엔드포인트 집합(초심자�
 
     @GetMapping("/check/email") // 이메일(로그인 ID) 중복 체크: true/false로 빠르게 응답
     public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkEmail(@RequestParam("value") String email) {
-        // 1) 이메일을 소문자 정규화하여 LOCAL 자격 기준으로만 검사합니다.
-        String normalized = email.trim().toLowerCase();
+        // 보안: 계정 열거(account enumeration) 완화
+        // - 실서비스에선 반드시 IP/디바이스 기준 레이트리밋(예: 분당 N회)을 적용하세요.
+        // - CAPTCHA나 가입 플로우 내부에서만 사용하도록 제한하는 것도 효과적입니다.
+        // - 이 데모는 레이트리밋 미구현 상태이므로, 운영 전 게이트 추가를 권장합니다.
+
+        String normalized = email.trim().toLowerCase(); // 입력 정규화
         boolean exists = authService.existsLocalEmail(normalized);
-        // 2) result에 {"exists": true/false} 형태로 담아 반환합니다.
         return ResponseEntity.ok(ApiResponse.onSuccess(Map.of("exists", exists)));
     }
 

--- a/src/main/java/com/salemale/domain/user/controller/AuthController.java
+++ b/src/main/java/com/salemale/domain/user/controller/AuthController.java
@@ -8,7 +8,7 @@ import jakarta.validation.Valid; // 요청 바디 검증
 import org.springframework.http.ResponseEntity; // HTTP 응답 래퍼
 import org.springframework.web.bind.annotation.PostMapping; // POST 매핑
 import org.springframework.web.bind.annotation.PatchMapping; // PATCH 매핑(로그아웃 등 상태변경용)
-import org.springframework.web.bind.annotation.GetMapping; // GET 매핑(중복 체크/상태 점검)
+import org.springframework.web.bind.annotation.GetMapping; // GET 매핑(상태 점검)
 import org.springframework.web.bind.annotation.RequestParam; // 쿼리 파라미터 바인딩
 import org.springframework.security.core.annotation.AuthenticationPrincipal; // 인증된 사용자 주입
 import org.springframework.security.core.userdetails.UserDetails; // 인증 주체 표현
@@ -54,8 +54,8 @@ public class AuthController { // 인증 관련 엔드포인트 집합(초심자�
         return ResponseEntity.ok(ApiResponse.onSuccess());
     }
 
-    @GetMapping("/check/login-id") // 이메일(로그인 ID) 중복 체크: true/false로 빠르게 응답
-    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkLoginId(@RequestParam("value") String email) {
+    @GetMapping("/check/email") // 이메일(로그인 ID) 중복 체크: true/false로 빠르게 응답
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkEmail(@RequestParam("value") String email) {
         // 1) 이메일을 소문자 정규화하여 LOCAL 자격 기준으로만 검사합니다.
         String normalized = email.trim().toLowerCase();
         boolean exists = authService.existsLocalEmail(normalized);

--- a/src/main/java/com/salemale/domain/user/controller/AuthController.java
+++ b/src/main/java/com/salemale/domain/user/controller/AuthController.java
@@ -8,6 +8,10 @@ import jakarta.validation.Valid; // 요청 바디 검증
 import org.springframework.http.ResponseEntity; // HTTP 응답 래퍼
 import org.springframework.web.bind.annotation.PostMapping; // POST 매핑
 import org.springframework.web.bind.annotation.PatchMapping; // PATCH 매핑(로그아웃 등 상태변경용)
+import org.springframework.web.bind.annotation.GetMapping; // GET 매핑(중복 체크/상태 점검)
+import org.springframework.web.bind.annotation.RequestParam; // 쿼리 파라미터 바인딩
+import org.springframework.security.core.annotation.AuthenticationPrincipal; // 인증된 사용자 주입
+import org.springframework.security.core.userdetails.UserDetails; // 인증 주체 표현
 import org.springframework.web.bind.annotation.RequestBody; // 요청 바디 바인딩
 import org.springframework.web.bind.annotation.RequestMapping; // 베이스 경로 매핑
 import org.springframework.web.bind.annotation.RestController; // REST 컨트롤러 선언
@@ -48,6 +52,35 @@ public class AuthController { // 인증 관련 엔드포인트 집합(초심자�
         // 서버 세션을 쓰지 않는 JWT 구조에서는 서버가 무언가 지울 상태가 없습니다.
         // 실서비스에선 "블랙리스트" 저장소를 운용하거나, 클라이언트가 토큰을 삭제하도록 안내합니다.
         return ResponseEntity.ok(ApiResponse.onSuccess());
+    }
+
+    @GetMapping("/check/login-id") // 이메일(로그인 ID) 중복 체크: true/false로 빠르게 응답
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkLoginId(@RequestParam("value") String email) {
+        // 1) 이메일을 소문자 정규화하여 LOCAL 자격 기준으로만 검사합니다.
+        String normalized = email.trim().toLowerCase();
+        boolean exists = authService.existsLocalEmail(normalized);
+        // 2) result에 {"exists": true/false} 형태로 담아 반환합니다.
+        return ResponseEntity.ok(ApiResponse.onSuccess(Map.of("exists", exists)));
+    }
+
+    @GetMapping("/check/nickname") // 닉네임 중복 체크: true/false 응답
+    public ResponseEntity<ApiResponse<Map<String, Boolean>>> checkNickname(@RequestParam("value") String nickname) {
+        // 1) 닉네임은 표시용이므로 그대로 검사(정책에 따라 trim/소문자화 가능)
+        boolean exists = authService.existsNickname(nickname);
+        // 2) {"exists": true/false}
+        return ResponseEntity.ok(ApiResponse.onSuccess(Map.of("exists", exists)));
+    }
+
+    @GetMapping("/me") // 로그인 상태 확인: 토큰이 유효하면 주체(subject: 이메일)를 반환, 아니면 401
+    public ResponseEntity<ApiResponse<Map<String, String>>> me(@AuthenticationPrincipal UserDetails principal) {
+        // 1) JwtAuthenticationFilter가 토큰을 검증하고 SecurityContext에 주체를 세팅합니다.
+        // 2) @AuthenticationPrincipal로 인증된 사용자 정보를 주입받을 수 있습니다.
+        if (principal == null) {
+            // 스프링 시큐리티가 자동으로 401을 보내도록 구성되어 있으나, 명시적으로 실패 응답을 줄 수도 있습니다.
+            return ResponseEntity.status(401)
+                    .body(ApiResponse.onFailure("COMMON401", "인증이 필요합니다.", null));
+        }
+        return ResponseEntity.ok(ApiResponse.onSuccess(Map.of("subject", principal.getUsername())));
     }
 }
 

--- a/src/main/java/com/salemale/domain/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/salemale/domain/user/dto/request/LoginRequest.java
@@ -1,0 +1,18 @@
+package com.salemale.domain.user.dto.request; // 로그인 요청 바디 DTO
+
+import jakarta.validation.constraints.Email; // 이메일 형식 검증 애노테이션
+import jakarta.validation.constraints.NotBlank; // 빈 문자열 금지 검증
+import lombok.Getter; // 게터 생성
+
+@Getter
+public class LoginRequest { // /api/auth/login 에서 사용하는 입력 모델
+
+    @Email // RFC 이메일 형식 검사
+    @NotBlank // null/빈문자열 방지
+    private String email;
+
+    @NotBlank // null/빈문자열 방지
+    private String password;
+}
+
+

--- a/src/main/java/com/salemale/domain/user/dto/request/SignupRequest.java
+++ b/src/main/java/com/salemale/domain/user/dto/request/SignupRequest.java
@@ -1,0 +1,27 @@
+package com.salemale.domain.user.dto.request; // 회원가입 요청 바디 DTO
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern; // 정규식 검증(비밀번호 정책)
+import lombok.Getter;
+
+@Getter
+public class SignupRequest { // /api/auth/signup 에서 사용하는 입력 모델
+
+    @Email
+    @NotBlank
+    private String email; // 가입 이메일(로컬 로그인에 사용)
+
+    @NotBlank
+    @Size(min = 2, max = 15)
+    private String nickname; // 표시 이름
+
+    @NotBlank
+    @Size(min = 8, max = 64)
+    @Pattern(
+            regexp = "^(?=.*[A-Z])(?=.*[a-z])(?=.*[0-9])(?=.*[^A-Za-z0-9]).{8,64}$",
+            message = "비밀번호는 대문자, 소문자, 숫자, 특수문자를 각각 1개 이상 포함해야 합니다."
+    )
+    private String password; // 원문 비밀번호(서버에서 해시 처리). 위 @Pattern으로 복합 규칙을 강제
+}

--- a/src/main/java/com/salemale/domain/user/entity/BlockList.java
+++ b/src/main/java/com/salemale/domain/user/entity/BlockList.java
@@ -1,30 +1,30 @@
-package com.salemale.domain.user.entity;
+package com.salemale.domain.user.entity; // 사용자 차단 관계 엔티티(한 사용자가 다른 사용자를 차단)
 
-import com.salemale.global.common.BaseEntity;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.salemale.global.common.BaseEntity; // 생성/수정 시간 등 공통 컬럼 상속
+import jakarta.persistence.*; // JPA 매핑 애노테이션
+import lombok.AccessLevel; // 생성자 접근 제한자
+import lombok.AllArgsConstructor; // 전체 필드 생성자
+import lombok.Builder; // 빌더 패턴
+import lombok.Getter; // 게터 생성
+import lombok.NoArgsConstructor; // 기본 생성자
 
-@Entity
-@Table(name = "block_list")
+@Entity // JPA 엔티티
+@Table(name = "block_list") // 차단 목록 테이블
 @Getter
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class BlockList extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id // PK
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // IDENTITY 전략
     private Long id;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY) // 차단을 하는 사용자
     @JoinColumn(name = "blocker_id", nullable = false)
     private User blocker;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = FetchType.LAZY) // 차단된 사용자
     @JoinColumn(name = "blocked_user_id", nullable = false)
     private User blocked;
 }

--- a/src/main/java/com/salemale/domain/user/entity/User.java
+++ b/src/main/java/com/salemale/domain/user/entity/User.java
@@ -1,25 +1,23 @@
-package com.salemale.domain.user.entity;
+package com.salemale.domain.user.entity; // 도메인: 사용자 프로필(인증수단은 UserAuth로 분리)
 
-import com.salemale.global.common.BaseEntity;
-import com.salemale.global.common.enums.AlarmChecked;
-import com.salemale.global.common.enums.LoginType;
-import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import com.salemale.global.common.BaseEntity; // 생성/수정 시간 등을 제공하는 공통 엔티티 상속
+import com.salemale.global.common.enums.AlarmChecked; // 알림 허용 여부를 표현하는 ENUM
+import com.salemale.global.common.enums.LoginType; // (참고) 로그인 제공자 ENUM. UserAuth에서 사용. User는 프로필만 보관
+import jakarta.persistence.*; // JPA 매핑 애노테이션 패키지 전반 사용(@Entity, @Column 등)
+import lombok.AccessLevel; // 생성자 접근 제한 수준 지정(PROTECTED)
+import lombok.AllArgsConstructor; // 모든 필드를 받는 생성자 자동 생성
+import lombok.Builder; // 빌더 패턴 자동 생성
+import lombok.Getter; // 필드에 대한 getter 자동 생성
+import lombok.NoArgsConstructor; // 파라미터 없는 생성자 자동 생성
 
-@Entity
+@Entity // JPA 엔티티로 매핑됨(테이블 레코드와 1:1 대응)
 @Table(
         name = "users",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_user_email", columnNames = {"email"}),
-                @UniqueConstraint(name = "uk_user_login_type_social_id", columnNames = {"login_type","social_id"})
+                @UniqueConstraint(name = "uk_user_email", columnNames = {"email"})
         },
         indexes = {
-                @Index(name = "idx_user_login_type", columnList = "login_type"),
-                @Index(name = "idx_user_social_id", columnList = "social_id")
+                @Index(name = "idx_user_phone_number", columnList = "phone_number")
         }
 )
 @Getter
@@ -28,45 +26,44 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class User extends BaseEntity {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id // 기본 키
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // DB의 AUTO_INCREMENT/IDENTITY 전략 사용
     private Long id;
 
-    @Enumerated(EnumType.STRING)
-    @Column(name = "login_type", nullable = false, columnDefinition = "VARCHAR(20)")
-    private LoginType loginType;
-
-    @Column(name = "nickname", nullable = false, length = 15)
+    @Column(name = "nickname", nullable = false, length = 15) // UI에 표시되는 별칭(서비스 정책에 따라 유니크 고려 가능)
     private String nickname;
 
-    @Column(name = "email", nullable = false, length = 254)
+    // 소셜 로그인에서 이메일 미제공이 가능하므로 nullable 허용
+    // 로컬 로그인 자격은 UserAuth.emailNormalized에 저장되고, User.email은 프로필 표시/연락 용도로 사용 가능
+    @Column(name = "email", nullable = true, length = 254)
     private String email;
 
-    @Column(name = "login_pw", length = 100)  // BCrypt(60) or Argon2(95) 수용
-    private String loginPw;
-
-    // 경매지수(혹은 매너지수)
-    @Builder.Default
+    // 경매지수(혹은 매너지수): 사용자 신뢰도/매너 지표로 사용
+    @Builder.Default // 빌더 사용 시 기본값 50 유지
     @Column(name = "manner_score", nullable = false)
     private Integer mannerScore = 50;
 
     // 반영할 거리 설정(1: 가까움, 2: 조금 먼, 3: 먼)
-    @Enumerated(EnumType.STRING)
+    @Enumerated(EnumType.STRING) // 문자열로 저장하여 enum 순서 변경의 위험 회피
     @Column(name = "range_setting")
-    private rangeSetting rangeSetting;
+    private RangeSetting rangeSetting;
 
-    @Column(name = "profile_image", length = 200)
+    @Column(name = "profile_image", length = 200) // 프로필 이미지 URL 등 경로 저장
     private String profileImage;
 
-    @Builder.Default
+    @Builder.Default // 기본값 NO
     @Enumerated(EnumType.STRING)
     @Column(name = "alarm_checked", nullable = false, columnDefinition = "VARCHAR(20)")
     private AlarmChecked alarmChecked = AlarmChecked.NO;
 
-    @Column(name = "social_id")
-    private String socialId;
+    // 휴대폰 본인인증 확장 대비: E.164(+821012345678) 규격 권장, 유니크로 중복 방지
+    @Column(name = "phone_number", length = 20, unique = true)
+    private String phoneNumber;
 
-    public enum rangeSetting {
-        가까움, 조금먼, 먼
+    @Column(name = "phone_verified_at") // 본인인증(휴대폰) 완료 시각 기록(존재 유무로 인증 여부 판단 가능)
+    private java.time.LocalDateTime phoneVerifiedAt;
+
+    public enum RangeSetting {
+        NEAR, MEDIUM, FAR // 가까움/중간/먼 거리 설정을 영문 상수로 관리(다국어 표시는 프론트/리소스에서 처리)
     }
 }

--- a/src/main/java/com/salemale/domain/user/entity/User.java
+++ b/src/main/java/com/salemale/domain/user/entity/User.java
@@ -13,9 +13,6 @@ import lombok.NoArgsConstructor; // 파라미터 없는 생성자 자동 생성
 @Entity // JPA 엔티티로 매핑됨(테이블 레코드와 1:1 대응)
 @Table(
         name = "users",
-        uniqueConstraints = {
-                @UniqueConstraint(name = "uk_user_email", columnNames = {"email"})
-        },
         indexes = {
                 @Index(name = "idx_user_phone_number", columnList = "phone_number")
         }

--- a/src/main/java/com/salemale/domain/user/entity/UserAuth.java
+++ b/src/main/java/com/salemale/domain/user/entity/UserAuth.java
@@ -9,7 +9,8 @@ import lombok.*; // 롬복(보일러플레이트 제거)
 @Table(
         name = "user_auth",
         uniqueConstraints = {
-                @UniqueConstraint(name = "uk_user_auth_provider_user", columnNames = {"provider", "provider_user_id"})
+                @UniqueConstraint(name = "uk_user_auth_provider_user", columnNames = {"provider", "provider_user_id"}),
+                @UniqueConstraint(name = "uk_user_auth_provider_email", columnNames = {"provider", "email_normalized"})
         },
         indexes = {
                 @Index(name = "idx_user_auth_provider_email", columnList = "provider,email_normalized")

--- a/src/main/java/com/salemale/domain/user/entity/UserAuth.java
+++ b/src/main/java/com/salemale/domain/user/entity/UserAuth.java
@@ -1,0 +1,53 @@
+package com.salemale.domain.user.entity; // 도메인: 사용자 인증수단(로컬/소셜) 관리 테이블
+
+import com.salemale.global.common.BaseEntity; // 공통 엔티티(생성/수정 시간 등)
+import com.salemale.global.common.enums.LoginType; // 인증 제공자 타입(LOCAL/KAKAO/NAVER)
+import jakarta.persistence.*; // JPA 매핑 애노테이션 전반
+import lombok.*; // 롬복(보일러플레이트 제거)
+
+@Entity // JPA 엔티티 선언
+@Table(
+        name = "user_auth",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_user_auth_provider_user", columnNames = {"provider", "provider_user_id"})
+        },
+        indexes = {
+                @Index(name = "idx_user_auth_provider_email", columnList = "provider,email_normalized")
+        }
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserAuth extends BaseEntity { // 인증 레코드(1 user : N auth)
+
+    @Id // PK
+    @GeneratedValue(strategy = GenerationType.IDENTITY) // IDENTITY 전략 사용
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false) // 다대일: 여러 인증수단이 한 사용자에 연결
+    @JoinColumn(name = "user_id", nullable = false,
+            foreignKey = @ForeignKey(name = "fk_user_auth_user")) // FK 명시로 스키마 가독성 향상
+    private User user;
+
+    @Enumerated(EnumType.STRING) // 문자열 저장(순서 변경 안전)
+    @Column(name = "provider", nullable = false, columnDefinition = "VARCHAR(20)")
+    private LoginType provider;
+
+    // LOCAL은 null, 소셜은 공급자 유저 ID 저장(예: 카카오 id)
+    @Column(name = "provider_user_id", length = 100)
+    private String providerUserId;
+
+    // 이메일 로그인용(소문자 정규화 저장), 소셜은 미제공 가능(이 경우 provider_user_id로만 식별)
+    @Column(name = "email_normalized", length = 254)
+    private String emailNormalized;
+
+    // LOCAL만 비밀번호 해시 저장(BCrypt 등): 원문 비밀번호는 저장 금지
+    @Column(name = "password_hash", length = 100)
+    private String passwordHash;
+
+    @Column(name = "last_login_at") // 최근 로그인 시간 기록(보안/통계용)
+    private java.time.LocalDateTime lastLoginAt;
+}
+
+

--- a/src/main/java/com/salemale/domain/user/repository/UserAuthRepository.java
+++ b/src/main/java/com/salemale/domain/user/repository/UserAuthRepository.java
@@ -9,6 +9,7 @@ import java.util.Optional; // Optional 반환으로 존재 여부 명확화
 public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
     Optional<UserAuth> findByProviderAndEmailNormalized(LoginType provider, String emailNormalized);
     Optional<UserAuth> findByProviderAndProviderUserId(LoginType provider, String providerUserId);
+    boolean existsByProviderAndEmailNormalized(LoginType provider, String emailNormalized);
 }
 
 

--- a/src/main/java/com/salemale/domain/user/repository/UserAuthRepository.java
+++ b/src/main/java/com/salemale/domain/user/repository/UserAuthRepository.java
@@ -1,0 +1,14 @@
+package com.salemale.domain.user.repository; // UserAuth 엔티티용 리포지토리(인증수단 조회 용도)
+
+import com.salemale.domain.user.entity.UserAuth; // 인증수단 엔티티
+import com.salemale.global.common.enums.LoginType; // 제공자 타입
+import org.springframework.data.jpa.repository.JpaRepository; // JPA 표준 리포지토리
+
+import java.util.Optional; // Optional 반환으로 존재 여부 명확화
+
+public interface UserAuthRepository extends JpaRepository<UserAuth, Long> {
+    Optional<UserAuth> findByProviderAndEmailNormalized(LoginType provider, String emailNormalized);
+    Optional<UserAuth> findByProviderAndProviderUserId(LoginType provider, String providerUserId);
+}
+
+

--- a/src/main/java/com/salemale/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/salemale/domain/user/repository/UserRepository.java
@@ -4,7 +4,8 @@ import com.salemale.domain.user.entity.User; // 도메인 엔티티
 import org.springframework.data.jpa.repository.JpaRepository; // 스프링 데이터 JPA 리포지토리
 
 public interface UserRepository extends JpaRepository<User, Long> {
-    // 필요 시 사용자 정의 조회 메서드 추가 예정
+    // 닉네임이 이미 존재하는지 여부를 빠르게 판단하기 위한 existsBy 쿼리 메서드
+    boolean existsByNickname(String nickname);
 }
 
 

--- a/src/main/java/com/salemale/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/salemale/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.salemale.domain.user.repository; // User 엔티티용 JPA 리포지토리(프로필 CRUD 담당)
+
+import com.salemale.domain.user.entity.User; // 도메인 엔티티
+import org.springframework.data.jpa.repository.JpaRepository; // 스프링 데이터 JPA 리포지토리
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    // 필요 시 사용자 정의 조회 메서드 추가 예정
+}
+
+

--- a/src/main/java/com/salemale/domain/user/service/AuthService.java
+++ b/src/main/java/com/salemale/domain/user/service/AuthService.java
@@ -1,0 +1,68 @@
+package com.salemale.domain.user.service; // 인증(로그인) 유스케이스를 담당하는 서비스 레이어
+
+import com.salemale.domain.user.entity.UserAuth; // 인증수단 엔티티(LOCAL/소셜)
+import com.salemale.domain.user.entity.User; // 사용자 프로필 엔티티
+import com.salemale.domain.user.dto.request.SignupRequest; // 회원가입 요청 DTO
+import com.salemale.domain.user.repository.UserRepository; // User 저장소
+import com.salemale.domain.user.repository.UserAuthRepository; // 인증수단 조회용 리포지토리
+import com.salemale.global.common.enums.LoginType; // 인증 제공자 타입(LOCAL, KAKAO, ...)
+import com.salemale.global.security.jwt.JwtTokenProvider; // 액세스 토큰 생성기
+import org.springframework.security.crypto.password.PasswordEncoder; // 비밀번호 해시 검증용
+import org.springframework.stereotype.Service; // 서비스 빈 선언
+
+@Service
+public class AuthService { // 응용 서비스: 컨트롤러와 리포지토리 사이 비즈니스 로직 구현
+
+    private final UserAuthRepository userAuthRepository;
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthService(UserAuthRepository userAuthRepository, UserRepository userRepository, PasswordEncoder passwordEncoder, JwtTokenProvider jwtTokenProvider) {
+        this.userAuthRepository = userAuthRepository;
+        this.userRepository = userRepository;
+        this.passwordEncoder = passwordEncoder;
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    public String loginLocal(String email, String rawPassword) {
+        String normalized = email.trim().toLowerCase(); // 이메일 정규화(대소문자 이슈 제거)
+        UserAuth auth = userAuthRepository.findByProviderAndEmailNormalized(LoginType.LOCAL, normalized)
+                .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
+        // 존재하지 않으면 인증 실패 처리
+
+        String hash = auth.getPasswordHash();
+        if (hash == null || !passwordEncoder.matches(rawPassword, hash)) {
+            throw new IllegalArgumentException("Invalid credentials");
+        }
+        // 비밀번호 불일치 시 실패
+
+        return jwtTokenProvider.generateToken(normalized); // 정상 시 JWT 발급(추후 userId/roles 등 클레임 확장 가능)
+    }
+
+    public void registerLocal(SignupRequest request) {
+        String normalized = request.getEmail().trim().toLowerCase();
+        // 중복 이메일 확인(LOCAL 자격 기준)
+        userAuthRepository.findByProviderAndEmailNormalized(LoginType.LOCAL, normalized)
+                .ifPresent(a -> { throw new IllegalArgumentException("Email already registered"); });
+
+        // 프로필 생성(표시용 이메일은 선택)
+        User user = User.builder()
+                .nickname(request.getNickname())
+                .email(request.getEmail())
+                .build();
+        user = userRepository.save(user);
+
+        // 비밀번호 해시 후 로컬 인증수단 저장
+        String hash = passwordEncoder.encode(request.getPassword());
+        UserAuth auth = UserAuth.builder()
+                .user(user)
+                .provider(LoginType.LOCAL)
+                .emailNormalized(normalized)
+                .passwordHash(hash)
+                .build();
+        userAuthRepository.save(auth);
+    }
+}
+
+

--- a/src/main/java/com/salemale/domain/user/service/AuthService.java
+++ b/src/main/java/com/salemale/domain/user/service/AuthService.java
@@ -68,9 +68,10 @@ public class AuthService { // 응용 서비스: 컨트롤러와 리포지토리 
         userAuthRepository.save(auth);
     }
 
-    public boolean existsLocalEmail(String normalizedEmail) {
+    public boolean existsLocalEmail(String email) {
+        String normalized = email.trim().toLowerCase();
         // LOCAL 제공자 기준으로 해당 이메일 자격이 이미 등록되어 있는지 검사합니다.
-        return userAuthRepository.existsByProviderAndEmailNormalized(LoginType.LOCAL, normalizedEmail);
+        return userAuthRepository.existsByProviderAndEmailNormalized(LoginType.LOCAL, normalized);
     }
 
     public boolean existsNickname(String nickname) {

--- a/src/main/java/com/salemale/domain/user/service/AuthService.java
+++ b/src/main/java/com/salemale/domain/user/service/AuthService.java
@@ -31,12 +31,12 @@ public class AuthService { // 응용 서비스: 컨트롤러와 리포지토리 
     public String loginLocal(String email, String rawPassword) {
         String normalized = email.trim().toLowerCase(); // 이메일 정규화(대소문자 이슈 제거)
         UserAuth auth = userAuthRepository.findByProviderAndEmailNormalized(LoginType.LOCAL, normalized)
-                .orElseThrow(() -> new IllegalArgumentException("Invalid credentials"));
+                .orElseThrow(() -> new GeneralException(ErrorStatus.AUTH_INVALID_CREDENTIALS));
         // 존재하지 않으면 인증 실패 처리
 
         String hash = auth.getPasswordHash();
         if (hash == null || !passwordEncoder.matches(rawPassword, hash)) {
-            throw new IllegalArgumentException("Invalid credentials");
+            throw new GeneralException(ErrorStatus.AUTH_INVALID_CREDENTIALS);
         }
         // 비밀번호 불일치 시 실패
 

--- a/src/main/java/com/salemale/domain/user/service/AuthService.java
+++ b/src/main/java/com/salemale/domain/user/service/AuthService.java
@@ -67,6 +67,16 @@ public class AuthService { // 응용 서비스: 컨트롤러와 리포지토리 
                 .build();
         userAuthRepository.save(auth);
     }
+
+    public boolean existsLocalEmail(String normalizedEmail) {
+        // LOCAL 제공자 기준으로 해당 이메일 자격이 이미 등록되어 있는지 검사합니다.
+        return userAuthRepository.existsByProviderAndEmailNormalized(LoginType.LOCAL, normalizedEmail);
+    }
+
+    public boolean existsNickname(String nickname) {
+        // 프로필(User) 테이블에서 닉네임 중복 여부를 검사합니다.
+        return userRepository.existsByNickname(nickname);
+    }
 }
 
 

--- a/src/main/java/com/salemale/global/security/SecurityConfig.java
+++ b/src/main/java/com/salemale/global/security/SecurityConfig.java
@@ -1,0 +1,57 @@
+package com.salemale.global.security; // 스프링 시큐리티 전역 설정
+
+import org.springframework.context.annotation.Bean; // @Bean 등록
+import org.springframework.context.annotation.Configuration; // 설정 클래스
+import org.springframework.security.config.Customizer; // 기본 httpBasic 설정 등
+import org.springframework.security.config.annotation.web.builders.HttpSecurity; // 보안 DSL
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity; // 시큐리티 활성화
+import org.springframework.security.config.http.SessionCreationPolicy; // 세션 정책(STATeless)
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder; // BCrypt 구현체
+import org.springframework.security.crypto.password.PasswordEncoder; // 비밀번호 인코더 인터페이스
+import org.springframework.security.web.SecurityFilterChain; // 필터 체인 빈
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter; // 커스텀 필터 삽입 지점
+import com.salemale.global.security.jwt.JwtAuthenticationFilter; // JWT 인증 필터
+import com.salemale.global.security.jwt.JwtTokenProvider; // 토큰 프로바이더
+
+@Configuration // 스프링 구성 클래스
+@EnableWebSecurity // 웹 보안 활성화
+public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider; // JWT 파서/생성기 주입
+
+    public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable()) // REST + JWT 환경에서 CSRF 보호 비활성화(상태 비저장)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 미사용
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/", // 루트
+                                "/swagger-ui.html", // 스웨거 UI
+                                "/swagger-ui/**",
+                                "/v3/api-docs/**",
+                                "/api-docs/**",
+                                "/actuator/health", // 헬스체크
+                                "/auth/**" // 로그인/회원가입/로그아웃 등 인증 경로는 공개
+                        ).permitAll()
+                        .anyRequest().authenticated() // 그 외는 인증 필요
+                )
+                .httpBasic(Customizer.withDefaults()); // httpBasic 기본값(사용 안 해도 무방)
+
+        // UsernamePasswordAuthenticationFilter 전에 JWT 인증 필터를 등록
+        http.addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build(); // 필터 체인 빌드
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder(); // BCrypt로 비밀번호 해시/검증
+    }
+}
+
+

--- a/src/main/java/com/salemale/global/security/SecurityConfig.java
+++ b/src/main/java/com/salemale/global/security/SecurityConfig.java
@@ -36,7 +36,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/api-docs/**",
                                 "/actuator/health", // 헬스체크
-                                "/auth/**" // 로그인/회원가입/로그아웃 등 인증 경로는 공개
+                                "/auth/**",
+                                "/api/auth/**" // 로그인/회원가입/로그아웃 등 인증 경로는 공개(과거 프리픽스 호환)
                         ).permitAll()
                         .anyRequest().authenticated() // 그 외는 인증 필요
                 )

--- a/src/main/java/com/salemale/global/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/salemale/global/security/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,60 @@
+package com.salemale.global.security.jwt; // 매 요청마다 Authorization 헤더의 JWT를 검증하는 필터
+
+import jakarta.servlet.FilterChain; // 필터 체인 제어
+import jakarta.servlet.ServletException; // 서블릿 예외
+import jakarta.servlet.http.HttpServletRequest; // 요청 객체
+import jakarta.servlet.http.HttpServletResponse; // 응답 객체
+import org.springframework.http.HttpHeaders; // 표준 헤더 상수(Authorization 등)
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken; // 인증 객체 표현
+import org.springframework.security.core.context.SecurityContextHolder; // 현재 스레드의 보안 컨텍스트
+import org.springframework.security.core.userdetails.User; // 간단한 UserDetails 구현
+import org.springframework.security.core.userdetails.UserDetails; // 인증 주체 표현 인터페이스
+import org.springframework.security.web.authentication.WebAuthenticationDetailsSource; // 요청 세부정보 바인딩
+import org.springframework.util.StringUtils; // 문자열 유틸
+import org.springframework.web.filter.OncePerRequestFilter; // 요청당 1회 실행 보장 필터
+
+import java.io.IOException; // IO 예외
+import java.util.Collections; // 빈 권한 컬렉션
+
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider; // 토큰 파싱/검증기
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // Authorization: Bearer <token> 형태의 헤더에서 토큰 추출
+        String bearer = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(bearer) && bearer.startsWith("Bearer ")) {
+            String token = bearer.substring(7);
+            try {
+                // 토큰 유효성/서명 검증 + subject 추출(여기서는 이메일 normalized)
+                String subject = jwtTokenProvider.getSubject(token);
+                // 간단한 인증 주체 생성(권한은 추후 확장 가능)
+                UserDetails principal = User.withUsername(subject).password("").authorities(Collections.emptyList()).build();
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        principal,
+                        null,
+                        principal.getAuthorities()
+                );
+                // 요청 메타데이터(IP, 세션 ID 등) 부착
+                authentication.setDetails(new WebAuthenticationDetailsSource().buildDetails(request));
+                // 현재 스레드의 SecurityContext에 인증 저장 → 이후 컨트롤러에서 @AuthenticationPrincipal 사용 가능
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            } catch (Exception ignored) {
+                // 토큰 파싱/검증 실패 시 인증정보를 비움(익명 사용자로 처리)
+                SecurityContextHolder.clearContext();
+            }
+        }
+
+        // 다음 필터로 진행
+        filterChain.doFilter(request, response);
+    }
+}
+
+

--- a/src/main/java/com/salemale/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/salemale/global/security/jwt/JwtTokenProvider.java
@@ -24,6 +24,10 @@ public class JwtTokenProvider {
             @Value("${jwt.access-token-validity}") long accessValidity,
             @Value("${jwt.refresh-token-validity}") long refreshValidity
     ) {
+        // 최소 32바이트(256비트) 이상 확인 - 부족하면 애플리케이션 시작을 막아 보안을 강제
+        if (secret.getBytes(StandardCharsets.UTF_8).length < 32) {
+            throw new IllegalArgumentException("JWT secret must be at least 32 bytes (256 bits) for HMAC-SHA");
+        }
         // 비밀키 문자열을 HMAC-SHA 키 객체로 변환. 최소 256bit 권장
         this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
         this.accessTokenValidityMs = accessValidity;

--- a/src/main/java/com/salemale/global/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/salemale/global/security/jwt/JwtTokenProvider.java
@@ -1,0 +1,60 @@
+package com.salemale.global.security.jwt; // JWT 토큰 생성/검증을 담당하는 컴포넌트
+
+import io.jsonwebtoken.Claims; // 토큰의 클레임(payload) 추출용 타입
+import io.jsonwebtoken.Jwts; // jjwt의 토큰 빌더/파서 진입점
+import io.jsonwebtoken.security.Keys; // HMAC 키 생성 유틸리티
+import org.springframework.beans.factory.annotation.Value; // application.yml 값 주입
+import org.springframework.stereotype.Component; // 스프링 빈 등록을 위한 애노테이션
+
+import java.nio.charset.StandardCharsets; // 문자열을 바이트로 변환 시 UTF-8 지정
+import javax.crypto.SecretKey; // HMAC 서명/검증에 사용하는 대칭키 타입
+import java.util.Date; // 발급/만료 시각 표현
+
+@Component // 스프링 컨테이너가 관리하는 싱글톤 빈으로 등록
+public class JwtTokenProvider {
+
+    // HMAC 서명에 사용할 키. 대칭키 방식(서버에서만 알고 있는 비밀키)
+    private final SecretKey signingKey;
+    // 액세스/리프레시 토큰 유효기간(ms)
+    private final long accessTokenValidityMs;
+    private final long refreshTokenValidityMs;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-validity}") long accessValidity,
+            @Value("${jwt.refresh-token-validity}") long refreshValidity
+    ) {
+        // 비밀키 문자열을 HMAC-SHA 키 객체로 변환. 최소 256bit 권장
+        this.signingKey = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenValidityMs = accessValidity;
+        this.refreshTokenValidityMs = refreshValidity;
+    }
+
+    // 주체(subject, 보통 이메일 또는 사용자 ID)로 서명된 JWT 생성
+    public String generateToken(String subject) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenValidityMs);
+        // jjwt 0.12 API: 빌더에 subject/시간/서명키를 설정 후 compact()
+        return Jwts.builder()
+                .subject(subject) // 토큰의 주체 설정(인증된 사용자 식별자)
+                .issuedAt(now) // 발급 시각(iat)
+                .expiration(expiry) // 만료 시각(exp)
+                .signWith(signingKey) // HMAC 서명
+                .compact();
+    }
+
+    // 서명 검증 후 토큰의 subject를 반환. 유효하지 않으면 예외 발생
+    public String getSubject(String token) {
+        // 1) 서명 검증을 위한 키 등록
+        // 2) 파서 빌드
+        // 3) 서명 검증과 함께 클레임 파싱
+        Claims claims = Jwts.parser()
+                .verifyWith(signingKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+        return claims.getSubject();
+    }
+}
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,7 +18,7 @@ spring:
   # JPA/Hibernate 설정
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,11 +2,11 @@ spring:
   application:
     name: salemale
   
-  # 관리자 계정 (환경변수)
-  security:
-    user:
-      name: ${ADMIN_USERNAME}
-      password: ${ADMIN_PASSWORD}
+  # # 관리자 계정 (환경변수)
+  # security:
+  #   user:
+  #     name: ${ADMIN_USERNAME}
+  #     password: ${ADMIN_PASSWORD}
   
   # PostgreSQL 데이터베이스
   datasource:
@@ -49,3 +49,9 @@ management:
   endpoint:
     health:
       show-details: when_authorized
+
+# JWT 설정: jjwt에서 사용할 비밀키와 만료시간(ms)
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-validity: ${JWT_ACCESS_TOKEN_VALIDITY}
+  refresh-token-validity: ${JWT_REFRESH_TOKEN_VALIDITY}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

- https://github.com/Team-SaleMale/BE/issues/23

## 🔑 주요 내용

- 닉네임 중복체크 API 구현
- 이메일 중복체크 API 구현
- 로그인 상태체크 API 구현

## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Full authentication API: login, signup, logout, “me”, and live email/nickname availability checks; stronger signup validation and optional phone number + verification.

- Security
  - JWT-based stateless authentication with secure password hashing; most endpoints now require authentication.

- Chores
  - Config updates for JWT and DB behavior; re-added staging env to ignore list and ignore generated sources.

- Bug Fixes
  - Added user-facing error for rate limiting and explicit error for already-registered email.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->