### PR TITLE
[FEAT] 경매 상품에 대해 찜하기 취소 api 구현

### DIFF
--- a/src/main/java/com/salemale/domain/item/controller/ItemLikeController.java
+++ b/src/main/java/com/salemale/domain/item/controller/ItemLikeController.java
@@ -33,4 +33,20 @@ public class ItemLikeController {
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
+
+    /**
+     * 경매 상품 찜 취소
+     * DELETE /auctions/{itemId}/liked
+     */
+    @Operation(summary = "경매 상품 찜 취소", description = "경매 상품 찜을 취소합니다.")
+    @DeleteMapping("/{itemId}/liked")
+    public ResponseEntity<ApiResponse<ItemLikeResponse>> unlikeItem(
+            @AuthenticationPrincipal UserDetails userDetails,
+            @PathVariable Long itemId
+    ) {
+        String email = userDetails.getUsername();
+        ItemLikeResponse response = itemLikeService.unlikeItem(email, itemId);
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
 }

--- a/src/main/java/com/salemale/domain/item/service/ItemLikeService.java
+++ b/src/main/java/com/salemale/domain/item/service/ItemLikeService.java
@@ -57,4 +57,26 @@ public class ItemLikeService {
         // 6. DTO로 응답 반환
         return ItemLikeResponse.of(itemId, true);
     }
+
+    @Transactional
+    public ItemLikeResponse unlikeItem(String email, Long itemId) {
+
+        // 1. 사용자 조회
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 상품 조회
+        Item item = itemRepository.findById(itemId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_FOUND));
+
+        // 3. 찜한 레코드 찾기
+        UserLiked userLiked = userLikedRepository.findByUserAndItem(user, item)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ITEM_NOT_LIKED));
+
+        // 4. 찜 취소 (삭제)
+        userLikedRepository.delete(userLiked);
+
+        // 5. 응답 반환
+        return ItemLikeResponse.of(itemId, false);
+    }
 }


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

#33 , feat/33-상품찜하기취소

## 🔑 주요 내용
경매 상품에 대해 찜하기 취소로직 구현
<img width="850" height="565" alt="image" src="https://github.com/user-attachments/assets/55f04b3d-d10e-4668-bfec-a0e4ac7217fe" />
<img width="846" height="737" alt="image" src="https://github.com/user-attachments/assets/22fdb867-c39c-4a31-b8c3-fc84b1fa7e50" />



## Check List

- [x] **Reviewers** 등록을 하였나요?
- [x] **Assignees** 등록을 하였나요?
- [x] **라벨(Label)** 등록을 하였나요?
- [x] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - You can now remove your like from an auction item you previously liked. The unlike action uses standard delete behavior and immediately updates the item’s like status to “unliked.”
  - Consistent response format is returned for both like and unlike actions, ensuring clear feedback in the app.
  - Error messages are shown if the item doesn’t exist or wasn’t previously liked, providing clearer guidance to complete the action.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->