### PR TITLE
[FEAT] 선호 카테고리 선택, 조회 api 구현

### DIFF
--- a/src/main/java/com/salemale/domain/mypage/controller/MypageController.java
+++ b/src/main/java/com/salemale/domain/mypage/controller/MypageController.java
@@ -1,8 +1,10 @@
 package com.salemale.domain.mypage.controller;
 
 import com.salemale.common.response.ApiResponse;
+import com.salemale.domain.mypage.dto.request.UpdatePreferredCategoryRequest;
 import com.salemale.domain.mypage.dto.response.LikedItemListResponse;
 import com.salemale.domain.mypage.dto.response.MyAuctionListResponse;
+import com.salemale.domain.mypage.dto.response.PreferredCategoryResponse;
 import com.salemale.domain.mypage.service.MypageService;
 import com.salemale.domain.mypage.enums.MyAuctionSortType;
 import com.salemale.domain.mypage.enums.MyAuctionType;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -88,6 +91,46 @@ public class MypageController {
         MyAuctionListResponse response = mypageService.getMyAuctions(
                 userId, type, sort, pageable
         );
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    /**
+     * 선호 카테고리 설정
+     * POST /mypage/category
+     */
+    @Operation(
+            summary = "선호 카테고리 설정",
+            description = "사용자의 선호 카테고리를 설정합니다. 기존 설정은 모두 삭제되고 새로운 카테고리로 대체됩니다."
+    )
+    @PostMapping("/category")
+    public ResponseEntity<ApiResponse<PreferredCategoryResponse>> updatePreferredCategories(
+            @Parameter(hidden = true) HttpServletRequest request,
+            @Valid @RequestBody UpdatePreferredCategoryRequest requestDto
+    ) {
+        Long userId = currentUserProvider.getCurrentUserId(request);
+        PreferredCategoryResponse response = mypageService.updatePreferredCategories(
+                userId,
+                requestDto.getCategories()
+        );
+
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    /**
+     * 선호 카테고리 조회
+     * GET /mypage/category
+     */
+    @Operation(
+            summary = "선호 카테고리 조회",
+            description = "사용자가 설정한 선호 카테고리 목록을 조회합니다."
+    )
+    @GetMapping("/category")
+    public ResponseEntity<ApiResponse<PreferredCategoryResponse>> getPreferredCategories(
+            @Parameter(hidden = true) HttpServletRequest request
+    ) {
+        Long userId = currentUserProvider.getCurrentUserId(request);
+        PreferredCategoryResponse response = mypageService.getPreferredCategories(userId);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }

--- a/src/main/java/com/salemale/domain/mypage/dto/request/UpdatePreferredCategoryRequest.java
+++ b/src/main/java/com/salemale/domain/mypage/dto/request/UpdatePreferredCategoryRequest.java
@@ -1,0 +1,21 @@
+package com.salemale.domain.mypage.dto.request;
+
+import com.salemale.global.common.enums.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "선호 카테고리 설정 요청")
+public class UpdatePreferredCategoryRequest {
+
+    @NotEmpty(message = "최소 1개 이상의 카테고리를 선택해야 합니다.")
+    @Size(max = 17, message = "최대 17개까지 선택 가능합니다.")
+    @Schema(description = "선호 카테고리 목록", example = "[\"SPORTS\", \"PLANT\", \"TICKET\"]")
+    private List<Category> categories;
+}

--- a/src/main/java/com/salemale/domain/mypage/dto/response/PreferredCategoryResponse.java
+++ b/src/main/java/com/salemale/domain/mypage/dto/response/PreferredCategoryResponse.java
@@ -1,0 +1,22 @@
+package com.salemale.domain.mypage.dto.response;
+
+import com.salemale.global.common.enums.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@Schema(description = "선호 카테고리 응답")
+public class PreferredCategoryResponse {
+
+    @Schema(description = "선호 카테고리 목록", example = "[\"SPORTS\", \"PLANT\", \"TICKET\"]")
+    private List<Category> categories;
+
+    @Schema(description = "총 선택된 카테고리 개수", example = "3")
+    private int count;
+}

--- a/src/main/java/com/salemale/domain/mypage/service/MypageService.java
+++ b/src/main/java/com/salemale/domain/mypage/service/MypageService.java
@@ -8,15 +8,15 @@ import com.salemale.domain.item.entity.ItemTransaction;
 import com.salemale.domain.item.repository.ItemRepository;
 import com.salemale.domain.item.repository.ItemTransactionRepository;
 import com.salemale.domain.item.repository.UserLikedRepository;
-import com.salemale.domain.mypage.dto.response.LikedItemListResponse;
-import com.salemale.domain.mypage.dto.response.MyAuctionItemDTO;
-import com.salemale.domain.mypage.dto.response.MyAuctionListResponse;
-import com.salemale.domain.mypage.dto.response.MyAuctionSummaryDTO;
+import com.salemale.domain.mypage.dto.response.*;
 import com.salemale.domain.user.entity.User;
+import com.salemale.domain.user.entity.UserPreferredCategory;
+import com.salemale.domain.user.repository.UserPreferredCategoryRepository;
 import com.salemale.domain.user.repository.UserRepository;
 import com.salemale.domain.mypage.enums.MyRole;
 import com.salemale.domain.mypage.enums.MyAuctionSortType;
 import com.salemale.domain.mypage.enums.MyAuctionType;
+import com.salemale.global.common.enums.Category;
 import com.salemale.global.common.enums.ItemStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -37,6 +37,7 @@ public class MypageService {
     private final ItemRepository itemRepository;
     private final ItemTransactionRepository itemTransactionRepository;
     private final UserLikedRepository userLikedRepository;
+    private final UserPreferredCategoryRepository preferredCategoryRepository;
 
     /**
      * 내 경매 목록 조회
@@ -205,6 +206,60 @@ public class MypageService {
                 .size(likedPage.getSize())
                 .hasNext(likedPage.hasNext())
                 .hasPrevious(likedPage.hasPrevious())
+                .build();
+    }
+
+    /**
+     * 선호 카테고리 설정
+     */
+    @Transactional
+    public PreferredCategoryResponse updatePreferredCategories(
+            Long userId,
+            List<Category> categories
+    ) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 기존 선호 카테고리 전체 삭제
+        preferredCategoryRepository.deleteByUser(user);
+
+        // 3. 새로운 선호 카테고리 저장
+        List<UserPreferredCategory> newPreferences = categories.stream()
+                .distinct() // 중복 제거
+                .map(category -> UserPreferredCategory.builder()
+                        .user(user)
+                        .category(category)
+                        .build())
+                .toList();
+
+        preferredCategoryRepository.saveAll(newPreferences);
+
+        // 4. 응답 생성
+        return PreferredCategoryResponse.builder()
+                .categories(categories.stream().distinct().toList())
+                .count(categories.size())
+                .build();
+    }
+
+    /**
+     * 선호 카테고리 조회
+     */
+    public PreferredCategoryResponse getPreferredCategories(Long userId) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.USER_NOT_FOUND));
+
+        // 2. 선호 카테고리 조회
+        List<Category> categories = preferredCategoryRepository.findByUser(user)
+                .stream()
+                .map(UserPreferredCategory::getCategory)
+                .toList();
+
+        // 3. 응답 생성
+        return PreferredCategoryResponse.builder()
+                .categories(categories)
+                .count(categories.size())
                 .build();
     }
 }

--- a/src/main/java/com/salemale/domain/user/entity/UserPreferredCategory.java
+++ b/src/main/java/com/salemale/domain/user/entity/UserPreferredCategory.java
@@ -1,0 +1,34 @@
+package com.salemale.domain.user.entity;
+
+import com.salemale.global.common.BaseEntity;
+import com.salemale.global.common.enums.Category;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_preferred_category",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_user_category",
+                        columnNames = {"user_id", "category"}
+                )
+        }
+)
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class UserPreferredCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false, length = 50)
+    private Category category;
+}

--- a/src/main/java/com/salemale/domain/user/repository/UserPreferredCategoryRepository.java
+++ b/src/main/java/com/salemale/domain/user/repository/UserPreferredCategoryRepository.java
@@ -1,0 +1,20 @@
+package com.salemale.domain.user.repository;
+
+import com.salemale.domain.user.entity.User;
+import com.salemale.domain.user.entity.UserPreferredCategory;
+import com.salemale.global.common.enums.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UserPreferredCategoryRepository extends JpaRepository<UserPreferredCategory, Long> {
+
+    // 사용자의 모든 선호 카테고리 조회
+    List<UserPreferredCategory> findByUser(User user);
+
+    // 사용자의 선호 카테고리 전체 삭제
+    void deleteByUser(User user);
+
+    // 사용자의 특정 카테고리 존재 여부 확인
+    boolean existsByUserAndCategory(User user, Category category);
+}


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치
#88 , feat/88-select-category

## 🔑 주요 내용
마이페이지에서 사용자가 관심 있는 카테고리를 다중 선택하여 설정할 수 있는 기능을 구현했습니다. 사용자는 17개의 카테고리 중 원하는 항목들을 선택할 수 있으며, 이를 기존 파이썬 추천 로직에도 추가할 예정.

#### 1. POST `/mypage/category` - 선호 카테고리 설정
사용자가 선호하는 카테고리 목록을 설정하는 API입니다. 요청 시 기존에 저장된 모든 선호 카테고리가 삭제되고, 새로운 선택 항목으로 전체 대체됩니다.
**Request Body:**
```json
{
  "categories": ["SPORTS", "PLANT", "TICKET"]
}
```
응답 화면
<img width="751" height="511" alt="image" src="https://github.com/user-attachments/assets/b5414c69-b242-4993-8aff-488bcf3bf03d" />

#### 2. GET `/mypage/category` - 선호 카테고리 조회
현재 사용자가 설정한 선호 카테고리 목록을 조회하는 API입니다.
<img width="856" height="467" alt="image" src="https://github.com/user-attachments/assets/260a7685-86a6-4029-8cd4-5e7eb19c4686" />


### 데이터베이스 변경 사항
#### 새로운 테이블 추가: `user_preferred_category`
사용자와 선호 카테고리 간의 다대다 관계를 관리하기 위해 중간 테이블을 추가
#### 제약조건
- UNIQUE 제약: `(user_id, category)` 조합의 중복 방지하여
-> 카테고리 선택할때마다 기존 내용 전부 삭제하고 저장하긴 하는데 혹시 몰라서 넣어놨스빈다

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can now set and manage their preferred categories in their profile settings
  * Add or update up to 17 favorite categories to personalize their experience
  * View current preferred categories anytime through their profile

<!-- end of auto-generated comment: release notes by coderabbit.ai -->