### PR TITLE
[REFACTOR] 채팅 조회 api 수정

### DIFF
--- a/src/main/java/com/salemale/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/salemale/domain/chat/controller/ChatController.java
@@ -32,12 +32,12 @@ public class ChatController {
      */
     @Operation(summary = "채팅방 목록 조회", description = "chatId와 읽지 않은 메세지 개수 표시.")
     @GetMapping("/chats")
-    public ResponseEntity<ApiResponse<List<ChatIdUnread>>> getChats(
-           @RequestHeader("user_id") Long me,           // USER가 속한 방들만
+    public ResponseEntity<ApiResponse<List<ChatSummaryResponse>>> getChats(
+           @RequestHeader("user-id") Long me,           // USER가 속한 방들만
            @RequestParam(defaultValue = "0") int page,  // 오프셋 페이징
            @RequestParam(defaultValue = "50") int size
     ) {
-        List<ChatIdUnread> result = chatService.getMyChatIds(me, page, size);
+        List<ChatSummaryResponse> result = chatService.getChatSummaries(me, page, size);
         return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
     /**
@@ -48,7 +48,7 @@ public class ChatController {
     @Operation(summary = "채팅방 자동 생성", description = "경매 낙찰시 채팅방이 생성됩니다.")
     @PostMapping("/items/{itemId}/chat")
     public ResponseEntity<ApiResponse<ChatResponse>> createChatForWinner(
-            @RequestHeader("user_id") Long me,
+            @RequestHeader("user-id") Long me,
             @PathVariable Long itemId
     ) {
         ChatResponse resp = chatService.createChatForItemWinner(itemId);
@@ -81,7 +81,7 @@ public class ChatController {
     @Operation(summary = "채팅방 나가기", description = "나간 시간이 기록됩니다.")
     @PatchMapping("/chats/{chatId}/exit")
     public ResponseEntity<ApiResponse<Void>> exitChat(
-            @RequestHeader("user_id") Long me,
+            @RequestHeader("user-id") Long me,
             @PathVariable Long chatId
     ) {
         chatService.exitChat(me, chatId);
@@ -96,7 +96,7 @@ public class ChatController {
     @Operation(summary = "채팅방 입장", description = "해당 채팅방의 메시지들이 반환되며 읽지 않은 메시지는 모두 읽음 처리됩니다.")
     @PostMapping("/chats/{chatId}/enter")
     public ResponseEntity<ApiResponse<ChatEnterResponse>> enter(
-            @RequestHeader("user_id") Long me,
+            @RequestHeader("user-id") Long me,
             @PathVariable Long chatId,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "50") int size
@@ -112,7 +112,7 @@ public class ChatController {
     @Operation(summary = "메세지 읽음 처리", description = "채팅방을 입장하지 않고 읽음 처리 기능을 넣을시 유지.")
     @PatchMapping("/chats/{chatId}/read")
     public ResponseEntity<ApiResponse<MessageDtos.ReadAllResponse>> readAllInChat(
-            @RequestHeader("user_id") Long me,
+            @RequestHeader("user-id") Long me,
             @PathVariable Long chatId
     ) {
         MessageDtos.ReadAllResponse res = chatService.markAllReadInChat(me, chatId);

--- a/src/main/java/com/salemale/domain/chat/controller/MessageController.java
+++ b/src/main/java/com/salemale/domain/chat/controller/MessageController.java
@@ -37,7 +37,7 @@ public class MessageController {
     @Operation(summary = "메시지 보내기", description = "채팅방(chatId)으로 메시지를 보냅니다.")
     @PostMapping("/messages")
     public ResponseEntity<ApiResponse<MessageResponse>> sendMessage(
-            @RequestHeader("user_id") Long me,
+            @RequestHeader("user-id") Long me,
             @RequestBody SendMessageRequest request
     ) {
         MessageResponse resp = messageService.send(me, request);
@@ -48,7 +48,7 @@ public class MessageController {
             description = "이미지를 업로드하고, 업로드 URL로 메시지를 저장합니다. 브로드캐스트는 Service에서 처리합니다.")
     @PostMapping(value = "/messages/image", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ResponseEntity<ApiResponse<MessageResponse>> sendImage(
-            @RequestHeader("user_id") Long me,
+            @RequestHeader("user-id") Long me,
             @RequestParam Long chatId,
             @RequestPart("file") MultipartFile file
     ) {

--- a/src/main/java/com/salemale/domain/chat/dto/ChatDtos.java
+++ b/src/main/java/com/salemale/domain/chat/dto/ChatDtos.java
@@ -53,6 +53,34 @@ public class ChatDtos {
     }
 
     /**
+     * (프론트 요청으로 추가)채팅방 목록 요약 응답
+     * partner: 현재 사용자(me)가 판매자면 구매자, 구매자면 판매자
+     * lastMessage: 최근 메시지(막 생성된 경우 -> null)
+     * unreadCount: 읽지 않은 개수
+     */
+    @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+    public static class ChatSummaryResponse {
+        private Long chatId;
+        private Partner partner;
+        private LastMessage lastMessage; // null 가능(대화 시작 전)
+        private Long unreadCount;
+
+        @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+        public static class Partner {
+            private Long id;
+            private String nickname;
+            private String profileImage;
+        }
+
+        @Getter @NoArgsConstructor @AllArgsConstructor @Builder
+        public static class LastMessage {
+            private String content;
+            private MessageType type;
+            private LocalDateTime sentAt;
+        }
+    }
+
+    /**
      채팅방 생성 결과 DTO
      - 새로 만든 채팅방의 ID만 반환 (생성 후 바로 입장 가능)
      */

--- a/src/main/java/com/salemale/domain/chat/repository/projection/ChatSummaryRow.java
+++ b/src/main/java/com/salemale/domain/chat/repository/projection/ChatSummaryRow.java
@@ -1,0 +1,16 @@
+package com.salemale.domain.chat.repository.projection;
+
+import java.time.LocalDateTime;
+
+public interface ChatSummaryRow {
+    Long getChatId();
+    Long getPartnerId();
+    String getPartnerNickname();
+    String getPartnerProfileImage();
+
+    String getLastContent();       // nullable
+    String getLastType();          // nullable (TEXT/IMAGE/URL)
+    LocalDateTime getLastSentAt(); // nullable
+
+    Long getUnreadCount();      // not null
+}

--- a/src/main/java/com/salemale/global/security/SecurityConfig.java
+++ b/src/main/java/com/salemale/global/security/SecurityConfig.java
@@ -113,7 +113,7 @@ public class SecurityConfig {
                 "http://127.0.0.1:8080" // 로컬(루프백 IP - 백엔드)
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")); // 허용 메서드
-        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "X-Email-Verify-Token", "USER_ID", "user_id", "Accept")); // 허용 헤더 (CORS preflight용, 대소문자 모두 허용)
+        configuration.setAllowedHeaders(Arrays.asList("Authorization", "Content-Type", "X-Requested-With", "X-Email-Verify-Token", "USER-ID", "user-id", "Accept")); // 허용 헤더 (CORS preflight용, 대소문자 모두 허용)
         configuration.setExposedHeaders(List.of("Authorization")); // 클라이언트에서 읽을 수 있는 응답 헤더
         configuration.setAllowCredentials(true); // 인증정보(쿠키/Authorization) 포함 허용
 


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

#105 

## 🔑 주요 내용

-마이페이지에서 채팅목록 조회시 상대방에 관한 정보(닉네임, 프로필이미지, 유저id)와 마지막 메시지(content, type,sentAt) 반환 추가


## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat list now displays enhanced summaries, including partner information and last message previews for better context.

* **Refactor**
  * Standardized internal header naming conventions for API consistency across chat-related endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->