### PR TITLE
[FIX] 마이페이지/찜한목록 조회시 시작가&현재가 반환값에 추가 

### DIFF
--- a/src/main/java/com/salemale/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/salemale/domain/item/converter/ItemConverter.java
@@ -157,6 +157,8 @@ public class ItemConverter {
                 .bidderCount(item.getBidCount())
                 .endTime(item.getEndTime())
                 .viewCount(item.getViewCount())  // 조회수 추가
+                .startPrice(item.getStartPrice())
+                .currentPrice(item.getCurrentPrice())
                 .build();
     }
 

--- a/src/main/java/com/salemale/domain/mypage/dto/response/LikedItemDTO.java
+++ b/src/main/java/com/salemale/domain/mypage/dto/response/LikedItemDTO.java
@@ -35,4 +35,10 @@ public class LikedItemDTO {
 
     @Schema(description = "조회수", example = "1944")
     private Long viewCount;
+
+    @Schema(description = "경매 시작 가격", example = "100000")
+    private Integer startPrice;
+
+    @Schema(description = "현재 입찰 가격", example = "150000")
+    private Integer currentPrice;
 }


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치
#120 , fix/120-modify-mypage-likedPage

## 🔑 주요 내용
마이페이지/찜한목록 조회시 시작가&현재가 반환값에 추가
<img width="853" height="733" alt="image" src="https://github.com/user-attachments/assets/f6ef5985-2eeb-4083-831e-77d6fecfd264" />


## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced liked items with additional pricing details: start price and current bid price are now displayed when viewing your liked items.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->