### PR TITLE
[FIX] 핫딜 조회 api 권한 검증 로직 제거

### DIFF
--- a/src/main/java/com/salemale/global/security/SecurityConfig.java
+++ b/src/main/java/com/salemale/global/security/SecurityConfig.java
@@ -24,6 +24,7 @@ import org.springframework.web.cors.CorsConfiguration; // CORS 정책 정의
 import org.springframework.web.cors.CorsConfigurationSource; // CORS 설정 소스
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource; // URL 패턴별 CORS 적용
 import jakarta.servlet.http.HttpServletResponse; // 응답 객체
+import org.springframework.http.HttpMethod;
 
 import java.util.HashMap;
 import java.util.Arrays; // 허용 메서드/헤더 나열에 사용
@@ -76,6 +77,7 @@ public class SecurityConfig {
                                 "/auctions", // 경매 상품 리스트 조회 (인증 선택적: RECOMMENDED 제외하고는 불필요)
                                 "/auctions/**" // 경매 상품 상세 조회 (인증 선택적: 공개 정보)
                         ).permitAll()
+                        .requestMatchers(HttpMethod.GET, "/hotdeals").permitAll() // 핫딜리스트 조회 인증없이 가능하도록, POST는 허용 안함
                         .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll() // CORS preflight 요청 허용
                         .anyRequest().authenticated() // 그 외는 인증 필요
                 )


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치
#122 

## 🔑 주요 내용
SecurityConfig.java 에 .requestMatchers(HttpMethod.GET, "/hotdeals").permitAll() // 핫딜리스트 조회 인증없이 가능하도록, POST는 허용 안함 추가하여 핫딜 상품 조회 로그인 없이도 가능하도록 구현
<img width="857" height="878" alt="image" src="https://github.com/user-attachments/assets/1b937d41-fd0f-488a-845d-10899f7e38ad" />
get 메서드는 로그인 없이도 되고
<img width="862" height="650" alt="image" src="https://github.com/user-attachments/assets/b9adfe4d-8953-4218-a19e-d1e6d9c611d5" />
post 메서드는 이전과 그대로 인증 없이는 사용 불가

## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Hot deals are now publicly accessible without authentication, enabling users to browse and view available deals without logging in. Creating or modifying deals remains restricted to authenticated users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->