### PR TITLE
[FIX]add item_type=AUCTION condition in itemRepository queries

### DIFF
--- a/src/main/java/com/salemale/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/salemale/domain/item/repository/ItemRepository.java
@@ -57,7 +57,8 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             SELECT i.*
             FROM item i
             JOIN region r ON i.region_id = r.region_id
-            WHERE i.item_status = CAST(:status AS varchar)
+            WHERE i.item_type = 'AUCTION'
+              AND i.item_status = CAST(:status AS varchar)
               AND (
                 6371 * acos(
                   LEAST(1, GREATEST(-1,
@@ -73,7 +74,8 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             SELECT count(1)
             FROM item i
             JOIN region r ON i.region_id = r.region_id
-            WHERE i.item_status = CAST(:status AS varchar)
+            WHERE i.item_type = 'AUCTION'
+              AND i.item_status = CAST(:status AS varchar)
               AND (
                 6371 * acos(
                   LEAST(1, GREATEST(-1,
@@ -98,7 +100,8 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
      */
     @Query("""
             SELECT i FROM Item i
-            WHERE i.itemStatus = :status
+            WHERE i.itemType = com.salemale.global.common.enums.ItemType.AUCTION
+              AND i.itemStatus = :status
               AND (
                 LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                  OR LOWER(i.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
@@ -119,7 +122,8 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
      */
     @Query("""
             SELECT i FROM Item i
-            WHERE i.itemStatus = :status
+            WHERE i.itemType = com.salemale.global.common.enums.ItemType.AUCTION
+              AND i.itemStatus = :status
               AND (
                 LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                  OR LOWER(i.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
@@ -153,7 +157,8 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
      */
     @Query("""
             SELECT i FROM Item i
-            WHERE i.itemStatus = :status
+            WHERE i.itemType = com.salemale.global.common.enums.ItemType.AUCTION
+              AND i.itemStatus = :status
               AND (:categories IS NULL OR i.category IN :categories)
               AND (:minPrice IS NULL OR i.currentPrice >= :minPrice)
               AND (:maxPrice IS NULL OR i.currentPrice <= :maxPrice)
@@ -181,7 +186,8 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             SELECT i.*
             FROM item i
             JOIN region r ON i.region_id = r.region_id
-            WHERE i.item_status = CAST(:status AS varchar)
+            WHERE i.item_type = 'AUCTION'
+              AND i.item_status = CAST(:status AS varchar)
               AND (
                 LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                  OR LOWER(i.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
@@ -201,7 +207,8 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             SELECT count(1)
             FROM item i
             JOIN region r ON i.region_id = r.region_id
-            WHERE i.item_status = CAST(:status AS varchar)
+            WHERE i.item_type = 'AUCTION'
+              AND i.item_status = CAST(:status AS varchar)
               AND (
                 LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                  OR LOWER(i.name) LIKE LOWER(CONCAT('%', :keyword, '%'))


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치
#133 

## 🔑 주요 내용
경매상품조회시 search/items 상품타입이 AUCTION인 상품만 조회되도록 변경, HOTDEAL 상품은 핫딜상품 조회 api에서만 조회될 수 있도록
<img width="855" height="748" alt="image" src="https://github.com/user-attachments/assets/2fdd593e-e6da-4da5-b31f-cbb8f1e2a936" />
AUCTION 타입 상품들만조회됨

<img width="861" height="755" alt="image" src="https://github.com/user-attachments/assets/b3e19ef8-b40d-4d7c-818f-b711e6123546" />
HOTDEAL타입 상품들은 /hotdeals api 호출시 조회됨
## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved query filtering to ensure only auction items are processed in relevant database operations, enhancing data consistency and accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->