### PR TITLE
[REFACTOR] 차단 여부 조회 api 추가

### DIFF
--- a/src/main/java/com/salemale/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/salemale/domain/chat/controller/ChatController.java
@@ -2,7 +2,6 @@ package com.salemale.domain.chat.controller; // 채팅 관련 컨트롤러 패�
 
 import com.salemale.common.response.ApiResponse;
 import com.salemale.domain.chat.dto.BlockResponse;
-import com.salemale.domain.chat.dto.BlockStatusResponse;
 import com.salemale.domain.chat.dto.ChatDtos.*; // 채팅 DTO 묶음 (요청/응답)
 import com.salemale.domain.chat.dto.MessageDtos;
 import com.salemale.domain.chat.service.ChatService; // 비즈니스 로직 담당 서비스 계층

--- a/src/main/java/com/salemale/domain/chat/controller/ChatController.java
+++ b/src/main/java/com/salemale/domain/chat/controller/ChatController.java
@@ -2,6 +2,7 @@ package com.salemale.domain.chat.controller; // 채팅 관련 컨트롤러 패�
 
 import com.salemale.common.response.ApiResponse;
 import com.salemale.domain.chat.dto.BlockResponse;
+import com.salemale.domain.chat.dto.BlockStatusResponse;
 import com.salemale.domain.chat.dto.ChatDtos.*; // 채팅 DTO 묶음 (요청/응답)
 import com.salemale.domain.chat.dto.MessageDtos;
 import com.salemale.domain.chat.service.ChatService; // 비즈니스 로직 담당 서비스 계층
@@ -11,6 +12,7 @@ import org.springframework.http.ResponseEntity; // HTTP 응답 객체
 import org.springframework.web.bind.annotation.*; // REST API용 어노테이션 (@GetMapping 등)
 import java.util.List; // 리스트 응답용
 import java.net.URI; //응답 헤더 생성
+import com.salemale.domain.chat.dto.BlockStatusResponse; //차단 여부
 import com.salemale.domain.chat.dto.ChatDtos.ChatIdUnread;
 
 /**
@@ -109,7 +111,7 @@ public class ChatController {
      -채팅방에서 대화 상대 차단
      */
     @Operation(summary = "대화 상대 차단", description = "상대방을 차단하고 상대방이 경매 등록한 물품이 보이지 않게 됨.")
-    @PostMapping("/{chatId}/block")
+    @PostMapping("/chats/{chatId}/block")
     public ResponseEntity<ApiResponse<BlockResponse>> blockPartner(
             @RequestHeader("user-id") Long me,
             @PathVariable Long chatId
@@ -123,7 +125,7 @@ public class ChatController {
      -채팅방에서 대화 상대 차단 해제
      */
     @Operation(summary = "대화 상대 차단 해제", description = "상대방을 차단 해제.")
-    @PostMapping("/{chatId}/unblock")
+    @PostMapping("/chats/{chatId}/unblock")
     public ResponseEntity<ApiResponse<BlockResponse>> unblockPartner(
             @RequestHeader("user-id") Long me,
             @PathVariable Long chatId
@@ -131,4 +133,17 @@ public class ChatController {
         BlockResponse res = chatService.unblockPartner(me, chatId);
         return ResponseEntity.ok(ApiResponse.onSuccess(res));
     }
+
+    @Operation(summary = "대화 상대 차단 여부 조회", description = "상대방을 차단 여부 조회.")
+    @GetMapping("/chats/{chatId}/block")
+    public ResponseEntity<ApiResponse<BlockStatusResponse>> getBlockStatus(
+            @RequestHeader("user-id") Long me,
+            @PathVariable Long chatId
+    ) {
+        BlockStatusResponse res = chatService.getBlockStatus(me, chatId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(res));
+    }
+
+
+
 }

--- a/src/main/java/com/salemale/domain/chat/dto/BlockStatusResponse.java
+++ b/src/main/java/com/salemale/domain/chat/dto/BlockStatusResponse.java
@@ -1,0 +1,12 @@
+package com.salemale.domain.chat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class BlockStatusResponse {
+
+    private boolean iBlockedPartner;   // 내가 상대를 차단했는지
+    private boolean partnerBlockedMe;  // 상대가 나를 차단했는지
+}

--- a/src/main/java/com/salemale/domain/chat/dto/ChatDtos.java
+++ b/src/main/java/com/salemale/domain/chat/dto/ChatDtos.java
@@ -25,11 +25,7 @@ public class ChatDtos {
         private Long sellerId; // 판매자 ID
         private Long buyerId;  // 구매자 ID
     }
-
-    //내가 이 대화 상대를 차단했는지 (프론트: true면 차단해제, false면 차단)
-    private boolean iBlockedPartner;
-
-
+ 
     /**채팅방 목록 : chatId + unreadCount
      */
     @Getter @NoArgsConstructor @AllArgsConstructor @Builder

--- a/src/main/java/com/salemale/domain/chat/dto/ChatDtos.java
+++ b/src/main/java/com/salemale/domain/chat/dto/ChatDtos.java
@@ -26,6 +26,9 @@ public class ChatDtos {
         private Long buyerId;  // 구매자 ID
     }
 
+    //내가 이 대화 상대를 차단했는지 (프론트: true면 차단해제, false면 차단)
+    private boolean iBlockedPartner;
+
 
     /**채팅방 목록 : chatId + unreadCount
      */
@@ -50,6 +53,11 @@ public class ChatDtos {
 
         //아이템 정보 추가
         private ItemSummary item;
+
+        // 내가 이 대화 상대를 차단했는지 여부
+        // true  -> 이미 차단됨
+        // false -> 차단 안 됨
+        private boolean iBlockedPartner;
 
         @Getter @NoArgsConstructor @AllArgsConstructor @Builder
         public static class Partner {


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

#142 

## 🔑 주요 내용

-refactor로 기존 채팅 목록 조회에 추가하는 방식으로 하려했으나 새로 api를 추가하는 방식으로 하여 사실상 feat
-차단 여부 목록 조회 방식 (이전 pr 코드래빗 피드백 반영)
<img width="582" height="508" alt="image" src="https://github.com/user-attachments/assets/a77a9050-7a99-45fa-bedd-e38783c6d70e" />
상대방 차단일때 true
<img width="600" height="542" alt="image" src="https://github.com/user-attachments/assets/dfa4ab1b-d64e-4294-9adc-2b01040f4df6" />
상대방 차단 해제일때 false 반환


## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added endpoint to query block status between chat participants.
  * Chat summaries now show whether you have blocked the partner.

* **Improvements**
  * Standardized block/unblock endpoint paths.
  * Improved validation and semantics for block/unblock actions, including clearer status responses.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->