### PR TITLE
Refactor/146 block

### DIFF
--- a/src/main/java/com/salemale/domain/item/controller/ItemController.java
+++ b/src/main/java/com/salemale/domain/item/controller/ItemController.java
@@ -185,6 +185,15 @@ public class ItemController {
         // Pageable 객체 생성
         Pageable pageable = PageRequest.of(page, size);
 
+        // 로그인 안 했으면 null
+        // 로그인 했으면 userId
+        Long loginUserId = null;
+        try {
+            loginUserId = currentUserProvider.getCurrentUserId(request);
+        } catch (Exception e) {
+            // 비로그인 요청이면 그대로 null 유지
+        }
+
         // 추가: RECOMMENDED 상태일 때는 별도 처리
         if (status == AuctionStatus.RECOMMENDED) {
             Long userId = currentUserProvider.getCurrentUserId(request);
@@ -193,7 +202,7 @@ public class ItemController {
         }
 
         // 서비스 호출
-        AuctionListResponse response = itemService.getAuctionList(status, categories, minPrice, maxPrice, sort, pageable);
+        AuctionListResponse response = itemService.getAuctionList(status, categories, minPrice, maxPrice, sort, pageable, loginUserId);
 
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }

--- a/src/main/java/com/salemale/domain/item/converter/ItemConverter.java
+++ b/src/main/java/com/salemale/domain/item/converter/ItemConverter.java
@@ -188,6 +188,30 @@ public class ItemConverter {
                 .build();
     }
 
+    //⭐추가 메서드: 차단 여부 포함 버전
+    public static AuctionListItemDTO toAuctionListItemDTO(
+            Item item,
+            boolean blockedSeller   // Service에서 계산된 값
+    ) {
+        List<String> imageUrls = item.getImages().stream()
+                .map(ItemImage::getImageUrl)
+                .collect(Collectors.toList());
+
+        return AuctionListItemDTO.builder()
+                .itemId(item.getItemId())
+                .title(item.getTitle())
+                .imageUrls(imageUrls)
+                .currentPrice(item.getCurrentPrice())
+                .bidderCount(item.getBidCount())
+                .endTime(item.getEndTime())
+                .viewCount(item.getViewCount())
+                .itemStatus(item.getItemStatus().name())
+                .startPrice(item.getStartPrice())
+                .createdAt(item.getCreatedAt())
+                .blockedSeller(blockedSeller) // 차단 여부
+                .build();
+    }
+
     /**
      * Item → MyAuctionItemDTO 변환
      * @param item 상품 엔티티

--- a/src/main/java/com/salemale/domain/item/dto/response/AuctionListItemDTO.java
+++ b/src/main/java/com/salemale/domain/item/dto/response/AuctionListItemDTO.java
@@ -48,4 +48,8 @@ public class AuctionListItemDTO {
 
     @Schema(description = "경매 시작 날짜")
     private LocalDateTime createdAt;     // 생성일(경매 시작날짜) 추가
+
+    // 로그인 사용자가 이 판매자를 차단했는지 여부
+    @Schema(description = "차단한 판매자의 상품인지 여부", example = "false")
+    private boolean blockedSeller;
 }

--- a/src/main/java/com/salemale/domain/item/repository/ItemRepository.java
+++ b/src/main/java/com/salemale/domain/item/repository/ItemRepository.java
@@ -60,13 +60,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             WHERE i.item_type = 'AUCTION'
               AND i.item_status = CAST(:status AS varchar)
               AND (
-                   :me IS NULL OR i.seller NOT IN (
-                   SELECT bl.blocked
-                   FROM BlockList bl
-                   WHERE bl.blocker.id = :me
-                   )
-              )
-              AND (
                 6371 * acos(
                   LEAST(1, GREATEST(-1,
                     cos(radians(:lat)) * cos(radians(CAST(r.latitude AS double precision))) *
@@ -84,13 +77,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             WHERE i.item_type = 'AUCTION'
               AND i.item_status = CAST(:status AS varchar)
               AND (
-                   :me IS NULL OR i.seller NOT IN (
-                   SELECT bl.blocked
-                   FROM BlockList bl
-                   WHERE bl.blocker.id = :me
-                    )
-              )
-              AND (
                 6371 * acos(
                   LEAST(1, GREATEST(-1,
                     cos(radians(:lat)) * cos(radians(CAST(r.latitude AS double precision))) *
@@ -106,7 +92,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             @Param("lat") double centerLat,
             @Param("lon") double centerLon,
             @Param("distanceKm") double distanceKm,
-            @Param("me") Long me,
             Pageable pageable
     );
 
@@ -118,13 +103,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             WHERE i.itemType = com.salemale.global.common.enums.ItemType.AUCTION
               AND i.itemStatus = :status
               AND (
-                    :me IS NULL OR i.seller NOT IN (
-                    SELECT bl.blocked
-                    FROM BlockList bl
-                    WHERE bl.blocker.id = :me
-                    )
-              )
-              AND (
                 LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                  OR LOWER(i.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
               )
@@ -133,7 +111,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
     Page<Item> searchItemsByKeyword(
             @Param("status") com.salemale.global.common.enums.ItemStatus status,
             @Param("keyword") String keyword,
-            @Param("me") Long me,
             Pageable pageable
     );
 
@@ -147,13 +124,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             SELECT i FROM Item i
             WHERE i.itemType = com.salemale.global.common.enums.ItemType.AUCTION
               AND i.itemStatus = :status
-              AND (
-                       :me IS NULL OR i.seller NOT IN (
-                       SELECT bl.blocked
-                       FROM BlockList bl
-                       WHERE bl.blocker.id = :me
-                       )
-               )
               AND (
                 LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                  OR LOWER(i.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
@@ -176,7 +146,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             @Param("isPopular") boolean isPopular,
             @Param("threeDaysAgo") LocalDateTime threeDaysAgo,
             @Param("now") LocalDateTime now,
-            @Param("me") Long me,
             Pageable pageable
     );
 
@@ -190,13 +159,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             SELECT i FROM Item i
             WHERE i.itemType = com.salemale.global.common.enums.ItemType.AUCTION
               AND i.itemStatus = :status
-              AND (
-                   :me IS NULL OR i.seller NOT IN (
-                   SELECT bl.blocked
-                   FROM BlockList bl
-                   WHERE bl.blocker.id = :me
-                   )
-              )
               AND (:categories IS NULL OR i.category IN :categories)
               AND (:minPrice IS NULL OR i.currentPrice >= :minPrice)
               AND (:maxPrice IS NULL OR i.currentPrice <= :maxPrice)
@@ -214,7 +176,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             @Param("isPopular") boolean isPopular,
             @Param("threeDaysAgo") LocalDateTime threeDaysAgo,
             @Param("now") LocalDateTime now,
-            @Param("me") Long me,
             Pageable pageable
     );
 
@@ -227,13 +188,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             JOIN region r ON i.region_id = r.region_id
             WHERE i.item_type = 'AUCTION'
               AND i.item_status = CAST(:status AS varchar)
-              AND (
-                       :me IS NULL OR i.seller NOT IN (
-                       SELECT bl.blocked
-                       FROM BlockList bl
-                       WHERE bl.blocker.id = :me
-                       )
-               )
               AND (
                 LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                  OR LOWER(i.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
@@ -256,13 +210,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             WHERE i.item_type = 'AUCTION'
               AND i.item_status = CAST(:status AS varchar)
               AND (
-                   :me IS NULL OR i.seller NOT IN (
-                   SELECT bl.blocked
-                   FROM BlockList bl
-                   WHERE bl.blocker.id = :me
-                   )
-              )
-              AND (
                 LOWER(i.title) LIKE LOWER(CONCAT('%', :keyword, '%'))
                  OR LOWER(i.name) LIKE LOWER(CONCAT('%', :keyword, '%'))
               )
@@ -283,7 +230,6 @@ public interface ItemRepository extends JpaRepository<Item, Long>, ItemRepositor
             @Param("lat") double centerLat,
             @Param("lon") double centerLon,
             @Param("distanceKm") double distanceKm,
-            @Param("me") Long me,
             Pageable pageable
     );
     Long countBySeller(User seller);


### PR DESCRIPTION
## 🎋 이슈 및 작업중인 브랜치

#146 

## 🔑 주요 내용

-차단한 사용자가 등록한 아이템을 보이지 않게 하던 방법에서 아이템에 차단한 사용자가 올린 아이템인지 알아볼 수 있게 플래그 생성
-처음에 itemrepository 쿼리를 수정하여 아이템을 필터링했던 방법의 문제점 : native query와 jpql의 충돌이 발생했는데 전체 수정하지 않는 이상 해결 불가
-그래서 두번째로 service 차원에서 필터링하려 하였으나 range=ALL일 때는 service 단계에서 차단할 수가 없음, page를 filter로 줄이면서 데이터 불일치 -> 스웨거 상에서 items =[] 비어있는데 totalElements=2와 같은 응답 발생
-최종적으로 차단한 판매자 아이템도 그대로 보이게 하되, 시각적으로 알아볼 수 있게 차단한 사용자가 등록했는지 플래그를 생성
순서대로 차단하지 않았을 때, 차단 했을 때의 캡쳐
"blockedSeller" = false/true
<img width="618" height="506" alt="image" src="https://github.com/user-attachments/assets/47c56a35-8abd-4a49-88aa-896bd2569c03" />
<img width="620" height="450" alt="image" src="https://github.com/user-attachments/assets/e754a57b-609e-45c2-a22b-005d19e324c4" />



## Check List

- [ ] **Reviewers** 등록을 하였나요?
- [ ] **Assignees** 등록을 하였나요?
- [ ] **라벨(Label)** 등록을 하였나요?
- [ ] PR 머지하기 전 반드시 **CI가 정상적으로 작동하는지 확인**해주세요!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Items from blocked sellers are now flagged in auction listings and search results (keyword and location-based), allowing users to easily identify products from blocked sellers in the marketplace.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->